### PR TITLE
Early h5py methods

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -19,7 +19,7 @@
 - [ ] modify requirements to be nested
         - SEE https://stackoverflow.com/a/20720019
         - add pylint to the dev requirements
-- [ ] add (implement) to/from disk for GeneData
+- [X] add (implement) to/from disk for GeneData
 - [X] refactor `import_transposons.py::import_trasnsposons` for input arg
         - input callable for preprocessing instead so client doesn't have to modify the import
         - see the comments on that function

--- a/transposon/data.py
+++ b/transposon/data.py
@@ -18,6 +18,8 @@ __author__ = "Michael Teresi, Scott Teresi"
 
 import logging
 import numpy as np
+import pandas as pd
+# import h5py
 
 
 class GeneData(object):
@@ -41,18 +43,43 @@ class GeneData(object):
         self.lengths = self.data_frame.Length.to_numpy(copy=False)
         self.chromosomes = self.data_frame.Chromosome.to_numpy(copy=False)
         self.unique_genes = gene_dataframe.index.unique()
+        # unique() returns a list, there ought to be one element in the list
+        # and we just want it in string form, so I index on 0 MAGIC NUMBER below
+        self.chrom_of_the_subset = self.data_frame.Chromosome.unique()[0]
 
-    def write(self, filename):
-        """Write to disk."""
+    def write(self, filename, key='default'):
+        """Write a Pandaframe to disk.
 
+            filename (str): a string of the filename you want to write.
+            key (str): identifier for the group in the store, since we can
+            write multiple pandaframes to an hdf5 file, we need a key string
+            identifer to grab a specific pandaframe from the hdf5, so I set a
+            default value. I imagine during production we will use the
+            chromosome as the key for each pandaframe in the hdf5.
+        """
+        # self.data_frame is a PandaFrame that is why we can use to_hdf
+        self.data_frame.to_hdf(filename, key=key, mode='w')
         # NOTE consider for map reduce?
-        raise NotImplementedError()
 
-    def read(self, filename):
-        """Read from disk."""
+    @staticmethod
+    def read(filename, key='default'):
+        """Read from disk. Returns a Pandaframe from an hdf5 file
 
+        Args:
+            filename (str): a string of the filename you want to read.
+            key (str): identifier for the group in the store, since we can
+            write multiple pandaframes to an hdf5 file, we need a key string
+            identifer to grab a specific pandaframe from the hdf5, so I set a
+            default value. I imagine during production we will use the
+            chromosome as the key for each pandaframe in the hdf5.
+        """
+        # MICHAEL, let me know if this syntax is good/appropriate.
+        # I made it a static method because you don't need self, but I make
+        # sure to use the Pandas method of reading an hdf because that is how
+        # we are initially constructing our dataset, so I thought it would be
+        # consistent.
+        return pd.read_hdf(filename, key=key)
         # NOTE consider for map reduce?
-        raise NotImplementedError()
 
     def get_gene(self, gene_id):
         """Return a GeneDatum for the gene identifier."""

--- a/transposon/density.py
+++ b/transposon/density.py
@@ -257,9 +257,14 @@ def process():
     for sub_gene, sub_te in zip(grouped_genes, grouped_TEs):
         gene_data = GeneData(sub_gene)
         te_data = TransposonData(sub_te)
+        # filename = 'Test.hdf5'
+        # chromosome_identifier = gene_data.chrom_of_the_subset
+        # gene_data.write(filename, key=chromosome_identifier)
+        # X = GeneData.read(filename, key=chromosome_identifier)
+
         # TODO validate the gene / te pair
 
-        # OLD, candidate for deletion
+        # OLD, candidate for deletion, Scott has added variable names
         # window_it = lambda: range(100, 1000, 100)  # TODO remove magic numbers, parametrize
         window_it = lambda: range(first_window_size, last_window_size,
                                   window_delta)


### PR DESCRIPTION
I wrote some methods for writing and reading hdf5 files. I thought that it would be good to accept a Pandaframe (and use Pandas' methods for working with hdf5) as the input since we are initially using, constructing and wrapping Pandaframes. If you don't like that I can look into using the numpy methods or the h5py methods of writing and reading hdf5 files. 

I wrote some docstrings for the read and write commands but they are little verbose. I can clarify if needed, but essentially when you construct an hdf5 file, you need to add a key or identifier for that given chunk of the hdf5. This is the "key" keyword argument during the read and write functions.

I propose using a string of the chromosome (and potentially the window size too) as the key, as I think that is the best identifier for a dataset. So to start working towards that I added an attribute called "chrom_of_the_subset" in the init sections of TransposonData and GeneData. It returns a string of the 1 chromosome for that subset and later we can use that string to label or access that specific chunk of data in the hdf5.

Finally, I don't really like how the "read" function is a staticmethod but the "write" function is an instance method, because that makes their usage syntax a teensy bit different. However I think it is the most clear. You may want to change this, let me know what you think.