### PR TITLE
Update config file usage, add new optional argument to density

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ Calculate TE density for every gene in a genome, along sliding windows, and corr
 # Usage:
 This code requires two input files. It requires an annotated gene file and an annotated TE file. Preferably, both files are in `gff` format, however the pipeline does work on `gtf` format, though support is not maintained for `gtf` formatted input data. TEs identities, which ought to be in the third column of the TE annotation file, should have a string name of the Order, followed by a `/`, and then the SuperFamily. For example, an entry might look like `LTR/Gypsey` or `DNA/DTH`.
 
-`python transposon/density.py /path/to/annotated/gene/file /path/to/annotated/TE/file`
-Edit the `transposon/replace_names.py` dictionary to accomodate changes to the TE naming scheme if you want to re-write some annotations or collapse some annotations together. 
+`python transposon/density.py /path/to/gene_annotation_file /path/to/TE_annotation_file /path/to/config_file`
+
+Edit the `transposon/replace_names.py` dictionary to accomodate changes to the TE naming scheme if you want to re-write some annotations or collapse some annotations together.
+
+## Configuration File:
+A configuration file is required by the density algorithm to set the beginning window size, window delta, and max window size variables. Two configuration files are located in the `config` folder. `test_run_config.ini` contains a setup for quickly testing the code. `production_run_config.ini` contains the paradigm that we use for our implementation of the code. When running `density.py` the code defaults to `test_run_config.ini`, however with the `-c` option the path to an optional configuration file may be supplied.
 
 # Requirements
 Please install Pip so that you may easily install Python packages.

--- a/config/production_run_config.ini
+++ b/config/production_run_config.ini
@@ -1,0 +1,4 @@
+[density_parameters]
+first_window_size = 500
+window_delta = 500
+last_window_size = 10000

--- a/config/test_run_config.ini
+++ b/config/test_run_config.ini
@@ -1,0 +1,4 @@
+[density_parameters]
+first_window_size = 100
+window_delta = 100
+last_window_size = 1000

--- a/transposon/density.py
+++ b/transposon/density.py
@@ -316,6 +316,10 @@ if __name__ == '__main__':
                         help='parent path of gene file')
     parser.add_argument('tes_input_file', type=str,
                         help='parent path of transposon file')
+    parser.add_argument('--config_file', '-c', type=str,
+                        default=os.path.join(path_main, '../../',
+                                             'config/test_run_config.ini'),
+                        help='parent path of config file')
     parser.add_argument('--output_dir', '-o', type=str,
                         default=os.path.join(path_main, '../..', 'results'),
                         help='parent directory to output results')
@@ -324,9 +328,10 @@ if __name__ == '__main__':
                         help='set debugging level to DEBUG')
 
     args = parser.parse_args()
-    args.output_dir = os.path.abspath(args.output_dir)
     args.genes_input_file = os.path.abspath(args.genes_input_file)
     args.tes_input_file = os.path.abspath(args.tes_input_file)
+    args.config_file = os.path.abspath(args.config_file)
+    args.output_dir = os.path.abspath(args.output_dir)
     log_level = logging.DEBUG if args.verbose else logging.INFO
     logger = logging.getLogger(__name__)
     coloredlogs.install(level=log_level)
@@ -343,23 +348,13 @@ if __name__ == '__main__':
     logger.info("Importing transposons, this may take a moment...")
     TE_Data = import_transposons(args.tes_input_file, te_annot_renamer)
 
-    # NOTE Config parser section
-    logger.info("Setting config file...")
-    config = ConfigParser()
-    # NOTE Set this as needed, may have to move elsewhere so people can edit
-    # MICHAEL for the sake of testing, I will leave the options as 100, 100,
-    # 1000, but during our production runs I intend for it to be 500, 500,
-    # 10000
-    config['density_parameters'] = {'first_window_size': 100,
-                                    'window_delta': 100,
-                                    'last_window_size': 1000}
-    with open('config.ini', 'w') as configfile:
-        config.write(configfile)
-
     logger.info("Reading config file...")
+    # NOTE
+    # Michael we could always pass the parser object to the process() function
+    # however that sections seems likely to change, let me know what you think,
+    # if the below variable assignments ought to be moved
     parser = ConfigParser()
-    parser.read('config.ini')
-    # Set the parameters for processing
+    parser.read(args.config_file)
     first_window_size = parser.getint('density_parameters', 'first_window_size')
     window_delta = parser.getint('density_parameters', 'window_delta')
     last_window_size = parser.getint('density_parameters', 'last_window_size')


### PR DESCRIPTION
Michael I have updated the config file usage. There is now an optional argument to supply the path to a config file, it defaults to a test config file which is now within a folder.

Finally, I have left a note at the bottom of _density.py_ about the location of the code in which the config file is read.